### PR TITLE
未复用控制器的情况不执行此中间件

### DIFF
--- a/src/ActionHook.php
+++ b/src/ActionHook.php
@@ -11,6 +11,9 @@ class ActionHook implements MiddlewareInterface
 {
     public function process(Request $request, callable $next) : Response
     {
+        if(!config('app.controller_reuse', true)){
+            return $next($request);
+        }
         if ($request->controller) {
             // 禁止直接访问beforeAction afterAction
             if ($request->action === 'beforeAction' || $request->action === 'afterAction') {


### PR DESCRIPTION
未复用控制器
$controller = Container::get($request->controller); 会新实列化一个控制器